### PR TITLE
add MISC options in PAR file + more LPT parsing utils

### DIFF
--- a/pleiades/nucData.py
+++ b/pleiades/nucData.py
@@ -106,21 +106,30 @@ def get_info(isotopic_str):
     """
     
     # Extract the element and its atomic number from the isotopic string
-    match = re.match(r'([A-Za-z]+)-?(\d+)', isotopic_str)
+    match = re.match(r'([A-Za-z]+)[-_]?(\d+)', isotopic_str)
     if match:
         element_name = match.group(1)
-        atomic_number = match.group(2)
+        atomic_number = int(match.group(2))
 
     return element_name, atomic_number
 
-def get_mass_from_ame(isotopic_str: str='U-238',verbose: bool=False)->float:
-    import re
-    pattern = r"\b([A-Z][a-z]?)-(\d+)\b"
-    if not re.search(pattern,isotopic_str):
-        # raise ValueError(f"isotopic_str should be in the format of Element-AtomicMass (U-235)")
+def get_mass_from_ame(isotopic_str: str='U-238')->float:
+    """Returns the atomic mass from AME tables according to the isotope name (E.g. Eu-153)
+
+    Args:
+        isotopic_str (str, optional): isotope name. Defaults to 'U-238'.
+
+    Returns:
+        float: the atomic mass in amu
+    """
+    # import re
+    # pattern = r"\b([A-Z][a-z]?)-(\d+)\b"
+    # if not re.search(pattern,isotopic_str):
+    #     # raise ValueError(f"isotopic_str should be in the format of Element-AtomicMass (U-235)")
         
     
     possible_isotopes_data_list = []
+
 
     element, atomic_number = get_info(isotopic_str)
     # Load the file into a list of lines
@@ -138,7 +147,7 @@ def get_mass_from_ame(isotopic_str: str='U-238',verbose: bool=False)->float:
             if (element in line[:25]) and (str(atomic_number) in line[:25]):
                 possible_isotopes_data = parse_ame_line(line)
                 possible_isotopes_data_list.append(possible_isotopes_data)
-        
+
         # If we didn't find any data for the isotope
         if len(possible_isotopes_data_list) == 0:
             raise ValueError("No data found for {} in {}".format(isotopic_str, nucelar_masses_file))
@@ -158,11 +167,12 @@ def get_mat_number(isotopic_str: str='U-238')-> int:
     Returns:
         int: mat number 
     """  
-    import re
-    pattern = r"\b([A-Z][a-z]?)-(\d+)\b"
-    if not re.search(pattern,isotopic_str):
-        raise ValueError(f"isotopic_str should be in the format of Element-AtomicMass (e.g. U-238)")
-    
+    # import re
+    # pattern = r"\b([A-Z][a-z]?)-(\d+)\b"
+    # if not re.search(pattern,isotopic_str):
+    #     raise ValueError(f"isotopic_str should be in the format of Element-AtomicMass (e.g. U-238)")
+    element, atomic_number = get_info(isotopic_str)
+
     # open the file containing the endf summary table
     with open(PWD.parent / "nucDataLibs/isotopeInfo/neutrons.list","r") as fid:
         pattern = r'\b\s*(\d+)\s*-\s*([A-Za-z]+)\s*-\s*(\d+)([A-Za-z]*)\b' # match the isotope name 
@@ -170,7 +180,7 @@ def get_mat_number(isotopic_str: str='U-238')-> int:
             # find match for an isotope string in the line
             match = re.search(pattern,line)
 
-            if match and match.expand(r'\2-\3')==isotopic_str:
+            if match and match.expand(r'\2-\3')==f"{element}-{atomic_number}":
                 # the mat number is a 4 digits string at the end of each line
                 matnumber = int(line[-5:])
                 return matnumber

--- a/pleiades/nucData.py
+++ b/pleiades/nucData.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import pathlib
+import re
 
 # current file location
 PWD = pathlib.Path(__file__).parent
@@ -105,16 +106,19 @@ def get_info(isotopic_str):
     """
     
     # Extract the element and its atomic number from the isotopic string
-    element = ''.join([c for c in isotopic_str if not c.isdigit()]).strip("-")
-    atomic_number = int(''.join([c for c in isotopic_str if c.isdigit()]))
+    match = re.match(r'([A-Za-z]+)-?(\d+)', isotopic_str)
+    if match:
+        element_name = match.group(1)
+        atomic_number = match.group(2)
 
-    return element, atomic_number
+    return element_name, atomic_number
 
 def get_mass_from_ame(isotopic_str: str='U-238',verbose: bool=False)->float:
     import re
     pattern = r"\b([A-Z][a-z]?)-(\d+)\b"
     if not re.search(pattern,isotopic_str):
-        raise ValueError(f"isotopic_str should be in the format of Element-AtomicMass (U-235)")
+        # raise ValueError(f"isotopic_str should be in the format of Element-AtomicMass (U-235)")
+        
     
     possible_isotopes_data_list = []
 

--- a/pleiades/nucData.py
+++ b/pleiades/nucData.py
@@ -110,6 +110,9 @@ def get_info(isotopic_str):
     if match:
         element_name = match.group(1)
         atomic_number = int(match.group(2))
+    else:
+        element_name = ""
+        atomic_number = None
 
     return element_name, atomic_number
 
@@ -150,7 +153,8 @@ def get_mass_from_ame(isotopic_str: str='U-238')->float:
 
         # If we didn't find any data for the isotope
         if len(possible_isotopes_data_list) == 0:
-            raise ValueError("No data found for {} in {}".format(isotopic_str, nucelar_masses_file))
+            # raise ValueError("No data found for {} in {}".format(isotopic_str, nucelar_masses_file))
+            return None 
         # If we found more than one isotope, then we need to find the correct one. 
         else:
             for iso in possible_isotopes_data_list:

--- a/pleiades/sammyInput.py
+++ b/pleiades/sammyInput.py
@@ -2,6 +2,7 @@ import configparser
 from pleiades import nucData as pnd
 from typing import List, Dict
 from contextlib import suppress
+import numpy as np
 
 class InputFile:
     """ InputFile class for the Sammy input file.
@@ -274,7 +275,7 @@ class InputFile:
             string: float field of the given width with the float right-justified.
         """
         # The ".4f" here denotes 4 decimal places. You can adjust if needed.
-        return f"{data:>{width}.4f}"
+        return f"{data:>{width}}"
 
     @staticmethod
     def format_type_I(data, width):

--- a/pleiades/sammyOutput.py
+++ b/pleiades/sammyOutput.py
@@ -41,11 +41,16 @@ class LptFile:
                 start_text=" CUSTOMARY CHI SQUARED DIVIDED",
                 skipped_rows=0,
                 line_format="float(line.split()[7])"),
+            "flight_path_length":dict(
+                start_text="    Flight Path=",
+                skipped_rows=0,
+                line_format="float(line.split()[2])"),
             "time_elapsed":dict(
                 start_text="                              Total time",
                 skipped_rows=0,
                 line_format="float(line.split()[3])"),
             }
+        
     
         self.LPT_SEARCH_PATTERNS = LPT_SEARCH_PATTERNS
             

--- a/pleiades/sammyOutput.py
+++ b/pleiades/sammyOutput.py
@@ -140,6 +140,32 @@ class LptFile:
             self.register_new_stats("vary_deltae_us","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[47:51].strip() else 0")
 
 
+    def register_misc_stats(self, register_vary:bool = False) -> None:
+        """
+        register misc params to the `stats` method
+
+        Args:
+            - register_vary: (bool) if True register also the vary parameters
+        """
+        self.register_new_stats("t0","    t-zero", 0, "float(line[13:24])")
+        self.register_new_stats("L0","    t-zero", 0, "float(line[42:53])")
+        self.register_new_stats("delta_L0","    Delta-L", 0, "float(line[13:24])")
+        self.register_new_stats("delta_L1","    Delta-L", 0, "float(line[50:61])")
+        self.register_new_stats("DE","    Delta-E=", 0, "float(line[13:24])")
+        self.register_new_stats("D0","    Delta-E=", 0, "float(line[52:63])")
+        self.register_new_stats("DlnE","    Delta-E=", 1, "float(line[13:24])")
+
+
+        if register_vary:
+            self.register_new_stats("vary_t0","    t-zero", 0, "1 if line[24:29].strip() else 0")
+            self.register_new_stats("vary_L0","    t-zero", 0, "1 if line[53:58].strip() else 0")
+            self.register_new_stats("vary_delta_L0","    Delta-L", 0, "1 if line[24:29].strip() else 0")
+            self.register_new_stats("vary_delta_L1","    Delta-L", 0, "1 if line[61:66].strip() else 0")
+            self.register_new_stats("vary_DE","    Delta-E=", 0, "1 if line[24:29].strip() else 0")
+            self.register_new_stats("vary_D0","    Delta-E=", 0, "1 if line[63:68].strip() else 0")
+            self.register_new_stats("vary_DlnE","    Delta-E=", 1, "1 if line[24:29].strip() else 0")                            
+
+        
     def register_abundances_stats(self,isotopes:list =[]) -> None:
         """
         register final isotopic abundances

--- a/pleiades/sammyOutput.py
+++ b/pleiades/sammyOutput.py
@@ -149,8 +149,8 @@ class LptFile:
         """
         self.register_new_stats("t0","    t-zero", 0, "float(line[13:24])")
         self.register_new_stats("L0","    t-zero", 0, "float(line[42:53])")
-        self.register_new_stats("delta_L0","    Delta-L", 0, "float(line[13:24])")
-        self.register_new_stats("delta_L1","    Delta-L", 0, "float(line[50:61])")
+        self.register_new_stats("delta_L1","    Delta-L", 0, "float(line[13:24])")
+        self.register_new_stats("delta_L0","    Delta-L", 0, "float(line[50:61])")
         self.register_new_stats("DE","    Delta-E=", 0, "float(line[13:24])")
         self.register_new_stats("D0","    Delta-E=", 0, "float(line[52:63])")
         self.register_new_stats("DlnE","    Delta-E=", 1, "float(line[13:24])")
@@ -159,8 +159,8 @@ class LptFile:
         if register_vary:
             self.register_new_stats("vary_t0","    t-zero", 0, "1 if line[24:29].strip() else 0")
             self.register_new_stats("vary_L0","    t-zero", 0, "1 if line[53:58].strip() else 0")
-            self.register_new_stats("vary_delta_L0","    Delta-L", 0, "1 if line[24:29].strip() else 0")
-            self.register_new_stats("vary_delta_L1","    Delta-L", 0, "1 if line[61:66].strip() else 0")
+            self.register_new_stats("vary_delta_L1","    Delta-L", 0, "1 if line[24:29].strip() else 0")
+            self.register_new_stats("vary_delta_L0","    Delta-L", 0, "1 if line[61:66].strip() else 0")
             self.register_new_stats("vary_DE","    Delta-E=", 0, "1 if line[24:29].strip() else 0")
             self.register_new_stats("vary_D0","    Delta-E=", 0, "1 if line[63:68].strip() else 0")
             self.register_new_stats("vary_DlnE","    Delta-E=", 1, "1 if line[24:29].strip() else 0")                            

--- a/pleiades/sammyOutput.py
+++ b/pleiades/sammyOutput.py
@@ -95,9 +95,12 @@ class LptFile:
                                                  skipped_rows=skipped_rows,
                                                  line_format=line_format)
         
-    def register_normalization_stats(self) -> None:
+    def register_normalization_stats(self, register_vary:bool = False) -> None:
         """
         register six normalization params to the `stats` method
+
+        Args:
+            - register_vary: (bool) if True register also the vary parameters
         """
         self.register_new_stats("normalization","   NORMALIZATION", 1, "float(line[1:12])")
         self.register_new_stats("constant_bg","   NORMALIZATION", 1, "float(line[18:29])")
@@ -106,15 +109,35 @@ class LptFile:
         self.register_new_stats("exponential_bg","    BCKG*EXP(.)", 1, "float(line[1:12])")
         self.register_new_stats("exp_decay_bg","    BCKG*EXP(.)", 1, "float(line[18:29])")
 
-    def register_broadening_stats(self) -> None:
+        if register_vary:
+            self.register_new_stats("vary_normalization","   NORMALIZATION", 1, "1 if line[13:17].strip() else 0")
+            self.register_new_stats("vary_constant_bg","   NORMALIZATION", 1, "1 if line[30:34].strip() else 0")
+            self.register_new_stats("vary_one_over_v_bg","   NORMALIZATION", 1, "1 if line[47:51].strip() else 0")
+            self.register_new_stats("vary_sqrt_energy_bg","   NORMALIZATION", 1, "1 if line[64:68].strip() else 0")
+            self.register_new_stats("vary_exponential_bg","    BCKG*EXP(.)", 1, "1 if line[13:17].strip() else 0")
+            self.register_new_stats("vary_exp_decay_bg","    BCKG*EXP(.)", 1, "1 if line[30:34].strip() else 0")
+
+    
+
+    def register_broadening_stats(self, register_vary:bool = False) -> None:
         """
         register five broadening params to the `stats` method
+
+        Args:
+            - register_vary: (bool) if True register also the vary parameters
         """
         self.register_new_stats("temperature","  TEMPERATURE      THICKNESS", 1, "float(line[1:12])")
         self.register_new_stats("thickness","  TEMPERATURE      THICKNESS", 1, "float(line[18:29])")
         self.register_new_stats("flight_path_spread","    DELTA-L         DELTA-T-GAUS", 1, "float(line[1:12])")
         self.register_new_stats("deltag_fwhm","    DELTA-L         DELTA-T-GAUS", 1, "float(line[18:29])")
         self.register_new_stats("deltae_us","    DELTA-L         DELTA-T-GAUS", 1, "float(line[35:46])")
+
+        if register_vary:
+            self.register_new_stats("vary_temperature","  TEMPERATURE      THICKNESS", 1, "1 if line[13:17].strip() else 0")
+            self.register_new_stats("vary_thickness","  TEMPERATURE      THICKNESS", 1, "1 if line[30:34].strip() else 0")
+            self.register_new_stats("vary_flight_path_spread","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[13:17].strip() else 0")
+            self.register_new_stats("vary_deltag_fwhm","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[30:34].strip() else 0")
+            self.register_new_stats("vary_deltae_us","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[47:51].strip() else 0")
 
 
     def register_abundances_stats(self,isotopes:list =[]) -> None:
@@ -127,7 +150,7 @@ class LptFile:
         """
         if isotopes:
             for num,isotope in enumerate(isotopes):
-                self.register_new_stats(f"weight_{isotope}"," Nuclide    Abundance", num+1, "float(line[12:18])")
+                self.register_new_stats(f"{isotope}"," Nuclide    Abundance", num+1, "float(line[12:18])")
         else:
             for num in range(5):
                 self.register_new_stats(f"weight_{num}"," Nuclide    Abundance", num+1, "float(line[12:18])")            

--- a/pleiades/sammyOutput.py
+++ b/pleiades/sammyOutput.py
@@ -133,11 +133,11 @@ class LptFile:
         self.register_new_stats("deltae_us","    DELTA-L         DELTA-T-GAUS", 1, "float(line[35:46])")
 
         if register_vary:
-            self.register_new_stats("vary_temperature","  TEMPERATURE      THICKNESS", 1, "1 if line[13:17].strip() else 0")
-            self.register_new_stats("vary_thickness","  TEMPERATURE      THICKNESS", 1, "1 if line[30:34].strip() else 0")
-            self.register_new_stats("vary_flight_path_spread","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[13:17].strip() else 0")
-            self.register_new_stats("vary_deltag_fwhm","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[30:34].strip() else 0")
-            self.register_new_stats("vary_deltae_us","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[47:51].strip() else 0")
+            self.register_new_stats("vary_temperature","  TEMPERATURE      THICKNESS", 1, "1 if line[12:17].strip() else 0")
+            self.register_new_stats("vary_thickness","  TEMPERATURE      THICKNESS", 1, "1 if line[29:34].strip() else 0")
+            self.register_new_stats("vary_flight_path_spread","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[12:17].strip() else 0")
+            self.register_new_stats("vary_deltag_fwhm","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[29:34].strip() else 0")
+            self.register_new_stats("vary_deltae_us","    DELTA-L         DELTA-T-GAUS", 1, "1 if line[46:51].strip() else 0")
 
 
     def register_misc_stats(self, register_vary:bool = False) -> None:

--- a/pleiades/sammyOutput.py
+++ b/pleiades/sammyOutput.py
@@ -99,22 +99,22 @@ class LptFile:
         """
         register six normalization params to the `stats` method
         """
-        self.register_new_stats("normalization","   NORMALIZATION", 1, "float(line[2:13])")
-        self.register_new_stats("constant_bg","   NORMALIZATION", 1, "float(line[19:29])")
-        self.register_new_stats("one_over_v_bg","   NORMALIZATION", 1, "float(line[36:47])")
-        self.register_new_stats("sqrt_energy_bg","   NORMALIZATION", 1, "float(line[53:63])")
-        self.register_new_stats("exponential_bg","    BCKG*EXP(.)", 1, "float(line[2:13])")
-        self.register_new_stats("exp_decay_bg","    BCKG*EXP(.)", 1, "float(line[19:29])")
+        self.register_new_stats("normalization","   NORMALIZATION", 1, "float(line[1:12])")
+        self.register_new_stats("constant_bg","   NORMALIZATION", 1, "float(line[18:29])")
+        self.register_new_stats("one_over_v_bg","   NORMALIZATION", 1, "float(line[35:46])")
+        self.register_new_stats("sqrt_energy_bg","   NORMALIZATION", 1, "float(line[52:63])")
+        self.register_new_stats("exponential_bg","    BCKG*EXP(.)", 1, "float(line[1:12])")
+        self.register_new_stats("exp_decay_bg","    BCKG*EXP(.)", 1, "float(line[18:29])")
 
     def register_broadening_stats(self) -> None:
         """
         register five broadening params to the `stats` method
         """
-        self.register_new_stats("temperature","  TEMPERATURE      THICKNESS", 1, "float(line[2:13])")
-        self.register_new_stats("thickness","  TEMPERATURE      THICKNESS", 1, "float(line[19:29])")
-        self.register_new_stats("flight_path_spread","    DELTA-L         DELTA-T-GAUS", 1, "float(line[2:13])")
-        self.register_new_stats("deltag_fwhm","    DELTA-L         DELTA-T-GAUS", 1, "float(line[19:29])")
-        self.register_new_stats("deltae_us","    DELTA-L         DELTA-T-GAUS", 1, "float(line[36:47])")
+        self.register_new_stats("temperature","  TEMPERATURE      THICKNESS", 1, "float(line[1:12])")
+        self.register_new_stats("thickness","  TEMPERATURE      THICKNESS", 1, "float(line[18:29])")
+        self.register_new_stats("flight_path_spread","    DELTA-L         DELTA-T-GAUS", 1, "float(line[1:12])")
+        self.register_new_stats("deltag_fwhm","    DELTA-L         DELTA-T-GAUS", 1, "float(line[18:29])")
+        self.register_new_stats("deltae_us","    DELTA-L         DELTA-T-GAUS", 1, "float(line[35:46])")
 
 
     def register_abundances_stats(self,isotopes:list =[]) -> None:

--- a/pleiades/sammyOutput.py
+++ b/pleiades/sammyOutput.py
@@ -230,7 +230,10 @@ class LptFile:
 
         
         initial_params = self.params.get_vary_params(only_vary=True)
-        final_params = {vary_key:(params[key], uncertainties[key],"1") for vary_key,key in zip(initial_params,params)}
+        if uncertainties:
+            final_params = {vary_key:(params[key], uncertainties[key],"1") for vary_key,key in zip(initial_params,params)}
+        else:
+            final_params = {vary_key:(params[key], "","1") for vary_key,key in zip(initial_params,params)}
         if only_vary:
             initial_params.update(final_params)
         else:

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -113,27 +113,29 @@ class ParFile:
         self._MISC_DELTA_FORMAT = {"vary_delta_L1":slice(7-1,7),
                                    "vary_delta_L0":slice(9-1,9),
                                    "delta_L1":slice(11-1,20),
-                                   "delta_L1_err":slice(21-1,30),
+                                #    "delta_L1_err":slice(21-1,30),
                                    "delta_L0":slice(31-1,40),
-                                   "delta_L0_err":slice(41-1,50)}
+                                #    "delta_L0_err":slice(41-1,50)
+                                   }
     
         self._MISC_TZERO_FORMAT = {"vary_t0":slice(7-1,7),
                                    "vary_L0":slice(9-1,9),
                                    "t0":slice(11-1,20),
-                                   "t0_err":slice(21-1,30),
+                                #    "t0_err":slice(21-1,30),
                                    "L0":slice(31-1,40),
-                                   "L0_err":slice(41-1,50),
+                                #    "L0_err":slice(41-1,50),
                                    "flight_path_length":slice(51-1,60)}
     
         self._MISC_DELTE_FORMAT = {"vary_DE":slice(7-1,7),
                                    "vary_D0":slice(9-1,9),
                                    "vary_DlnE":slice(10-1,10),
                                    "DE":slice(11-1,20),
-                                   "DE_err":slice(21-1,30),
+                                #    "DE_err":slice(21-1,30),
                                    "D0":slice(31-1,40),
-                                   "D0_err":slice(41-1,50),
+                                #    "D0_err":slice(41-1,50),
                                    "DlnE":slice(51-1,60),
-                                   "DlnE_err":slice(61-1,70)}
+                                #    "DlnE_err":slice(61-1,70)
+                                  }
         
 
 
@@ -740,7 +742,7 @@ class Update():
         for num, res in enumerate(self.parent.data["resonance_params"]):
             # cast all numbers such as "3.6700-5" to floats
             energy = "e-".join(res['reosnance_energy'].split("-")).lstrip("e").replace("+","e+") if not "e" in res['reosnance_energy'] else res['reosnance_energy']
-            if self.parent.emin <=  float(energy) < self.parent.emax:
+            if float(self.parent.emin) <=  float(energy) < float(self.parent.emax):
                 new_res_params.append(res)
                 igroups.add(res["igroup"].strip())
         
@@ -874,21 +876,13 @@ class Update():
 
         Args:
               - delta_L1 (float) DELL11
-              - delta_L1_err (float) D1
               - delta_L0 (float) DELL00
-              - delta_L0_err (float) D0
               - t0 (float) TZERO
               - L0 (float) LZERO
-              - t0_err (float) DTZERO
-              - L0_err (float) DLZERO
               - flight_path_length (float) FPL
               - D0 (float) DELE0
               - DE (float) DELE1
               - DlnE (float) DELEL
-              - D0_err (float) DD0
-              - DE_err (float) DD1
-              - DlnE_err (float) DDL
-
 
               - vary_delta_L1 (int) 0=fixed, 1=vary, 2=pup
               - vary_delta_L0 (int) 0=fixed, 1=vary, 2=pup
@@ -901,26 +895,19 @@ class Update():
         if "misc" not in self.parent.data:
             self.parent.data["misc"] = {"vary_delta_L1":       "",                     
                                         "vary_delta_L0":       "",                     
-                                        "delta_L1":            "",             
-                                        "delta_L1_err":        "",                 
-                                        "delta_L0":            "",             
-                                        "delta_L0_err":        "",                 
+                                        "delta_L1":            "",                           
+                                        "delta_L0":            "",                            
                                         "vary_t0":             "",             
                                         "vary_L0":             "",             
-                                        "t0":                  "",         
-                                        "t0_err":              "",             
-                                        "L0":                  "",         
-                                        "L0_err":              "",             
+                                        "t0":                  "",                  
+                                        "L0":                  "",                
                                         "flight_path_length":  "",                         
                                         "vary_DE":             "",             
                                         "vary_D0":             "",             
                                         "vary_DlnE":           "",                 
-                                        "DE":                  "",         
-                                        "DE_err":              "",             
-                                        "D0":                  "",         
-                                        "D0_err":              "",             
-                                        "DlnE":                "",         
-                                        "DlnE_err":            "",             
+                                        "DE":                  "",                    
+                                        "D0":                  "",              
+                                        "DlnE":                "",                  
                                          }
 
         self.parent.data["misc"].update({key:value for key,value in kwargs.items() if key in self.parent.data["misc"]})

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -308,12 +308,15 @@ class ParFile:
             lines.append("")
 
         # misc
-        if self.data["misc"]:
+        if any(self.data["misc"].values()):
             lines.append('MISCELLANEOUS PARAMETERS FOLLOW'.ljust(80))
             card = self.data["misc"]
-            lines.append(self._write_misc_delta(card))
-            lines.append(self._write_misc_tzero(card))
-            lines.append(self._write_misc_deltE(card))
+            if any([value for key,value in self.data["misc"].items() if key in self._MISC_DELTA_FORMAT]):
+                lines.append(self._write_misc_delta(card))
+            if any([value for key,value in self.data["misc"].items() if key in self._MISC_TZERO_FORMAT]):
+                lines.append(self._write_misc_tzero(card))
+            if any([value for key,value in self.data["misc"].items() if key in self._MISC_DELTE_FORMAT]):
+                lines.append(self._write_misc_deltE(card))
             lines.append(" "*80)
             lines.append("")
 
@@ -834,7 +837,7 @@ class Update():
                                                  "vary_exponential_bg":0,
                                                  "vary_exp_decay_bg":0,}    
                        
-        self.parent.data["normalization"].update(kwargs)
+        self.parent.data["normalization"].update({key:value for key,value in kwargs.items() if key in self.parent.data["normalization"]})
 
 
     def broadening(self, **kwargs) -> None:
@@ -866,7 +869,7 @@ class Update():
                                                  "vary_deltag_fwhm":0,
                                                  "vary_deltae_us":0,}
 
-        self.parent.data["broadening"].update(kwargs)
+        self.parent.data["broadening"].update({key:value for key,value in kwargs.items() if key in self.parent.data["broadening"]})
 
     def misc(self, **kwargs) -> None:
         """change or vary misc parameters and vary flags
@@ -898,22 +901,22 @@ class Update():
               - vary_DlnE (int) 0=fixed, 1=vary, 2=pup
         """
         if "misc" not in self.parent.data:
-            self.parent.data["misc"] = {"vary_delta_L1":       "0",                     
-                                        "vary_delta_L0":       "0",                     
+            self.parent.data["misc"] = {"vary_delta_L1":       "",                     
+                                        "vary_delta_L0":       "",                     
                                         "delta_L1":            "",             
                                         "delta_L1_err":        "",                 
                                         "delta_L0":            "",             
                                         "delta_L0_err":        "",                 
-                                        "vary_t0":             "0",             
-                                        "vary_L0":             "0",             
+                                        "vary_t0":             "",             
+                                        "vary_L0":             "",             
                                         "t0":                  "",         
                                         "t0_err":              "",             
                                         "L0":                  "",         
                                         "L0_err":              "",             
                                         "flight_path_length":  "",                         
-                                        "vary_DE":             "0",             
-                                        "vary_D0":             "0",             
-                                        "vary_DlnE":           "0",                 
+                                        "vary_DE":             "",             
+                                        "vary_D0":             "",             
+                                        "vary_DlnE":           "",                 
                                         "DE":                  "",         
                                         "DE_err":              "",             
                                         "D0":                  "",         
@@ -922,10 +925,10 @@ class Update():
                                         "DlnE_err":            "",             
                                          }
 
-        self.parent.data["misc"].update(kwargs)
+        self.parent.data["misc"].update({key:value for key,value in kwargs.items() if key in self.parent.data["misc"]})
 
                                                  
-    def set_all_vary(self,vary=True,data_key="misc_delta"):
+    def vary_all(self,vary=True,data_key="misc_delta"):
         """toggle all vary parameters in a data keyword to either vary/fixed
 
         Args:
@@ -937,8 +940,8 @@ class Update():
                         - 'broadeninig'
                         - 'normalization'
         """
-        key_word = data_key.split("_")[0]
-        data_dict = getattr(self,f"_{data_key.upper()}_FORMAT")
+        keyword = data_key.split("_")[0]
+        data_dict = getattr(self.parent,f"_{data_key.upper()}_FORMAT")
         self.parent.data[keyword].update({key:int(vary) for key in data_dict if key.startswith("vary_")})
 
 

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -133,7 +133,7 @@ class ParFile:
                                    "D0":slice(31-1,40),
                                    "D0_err":slice(41-1,50),
                                    "DlnE":slice(51-1,60),
-                                   "DlnE_err":slice(51-1,60)}
+                                   "DlnE_err":slice(61-1,70)}
         
 
 

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -586,8 +586,8 @@ class ParFile:
         """ parse a list of isotopic_masses cards, sort the key-word values
         """
         im_dicts = {}
-        for card in self._isotopic_masses_cards:
-            im_dicts.append(self._read_isotopic_masses(card))
+        for isotope,card in zip(self.data["particle_pairs"],self._isotopic_masses_cards):
+            im_dicts.update(**{isotope["name"]: self._read_isotopic_masses(card)})
 
         self.data.update({"isotopic_masses":im_dicts})
 
@@ -813,7 +813,7 @@ class Update():
         """
         if self.parent.data["isotopic_masses"]:
             for card in self.parent.data["isotopic_masses"]:
-                card["abundance"] = f"{f'{self.parent.weight:.7f}':>9}"[:9]
+                self.parent.data["isotopic_masses"][card]["abundance"] = f"{f'{self.parent.weight:.7f}':>9}"[:9]
         else:
             spin_groups = [f"{group[0]['group_number'].strip():>5}" for group in self.parent.data["spin_group"]]
                 

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -1,5 +1,7 @@
 import re
 import pathlib
+import shelve
+import configparser
 from typing import Tuple, List, Dict, Any
 
 class ParFile:
@@ -324,7 +326,14 @@ class ParFile:
 
         
         with open(filename,"w") as fid:
-            fid.write("\n".join(lines))    
+            fid.write("\n".join(lines)) 
+
+        # write the self.data dictionary to a config.ini file
+        with open(f'{filename.with_name("params.ini")}',"w") as fid:
+            config = configparser.ConfigParser()
+            config.update({key:self.data[key] for key in ['normalization', 'broadening', 'misc']})
+            config.write(fid)
+
         
     def _rename(self) -> None:
         """rename the isotope and particle-pair names

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -745,7 +745,7 @@ class ParFile:
         for key,slice_value in self._RESOLUTION_FORMAT.items():
             word_length = slice_value.stop - slice_value.start
             # assign the fixed-format position with the corresponding key-word value
-            new_text[slice_value] = list(str(resolution_dict[key]).ljust(word_length))
+            new_text[slice_value] = list(str(resolution_dict[key]).ljust(word_length)[:word_length])
         return "".join(new_text)
 
 

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -292,7 +292,7 @@ class ParFile:
             lines.append("")
 
         # normalization
-        if self.data["normalization"]:
+        if any(self.data["normalization"].values()):
             lines.append("NORMALIZATION AND BACKGROUND FOLLOW".ljust(80))
             card = self.data["normalization"]
             lines.append(self._write_normalization(card))
@@ -300,7 +300,7 @@ class ParFile:
             lines.append("")
 
         # broadening
-        if self.data["broadening"]:
+        if any(self.data["broadening"].values()):
             lines.append("BROADENING PARAMETERS MAY BE VARIED".ljust(80))
             card = self.data["broadening"]
             lines.append(self._write_broadening(card))

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -111,6 +111,31 @@ class ParFile:
                                      "vary_flight_path_spread":slice(67-1,68),
                                      "vary_deltag_fwhm":slice(69-1,70),
                                      "vary_deltae_us":slice(71-1,72)}
+    
+        self._MISC_DELTA_FORMAT = {"vary_delta_L1":slice(7-1,7),
+                                   "vary_delta_L0":slice(9-1,9),
+                                   "delta_L1":slice(11-1,20),
+                                   "delta_L1_err":slice(21-1,30),
+                                   "delta_L0":slice(31-1,40),
+                                   "delta_L0_err":slice(41-1,50)}
+    
+        self._MISC_TZERO_FORMAT = {"vary_t0":slice(7-1,7),
+                                   "vary_L0":slice(9-1,9),
+                                   "t0":slice(11-1,20),
+                                   "t0_err":slice(21-1,30),
+                                   "L0":slice(31-1,40),
+                                   "L0_err":slice(41-1,50),
+                                   "flight_path_length":slice(51-1,60)}
+    
+        self._MISC_DELTE_FORMAT = {"vary_DE":slice(7-1,7),
+                                   "vary_D0":slice(9-1,9),
+                                   "vary_DlnE":slice(10-1,10),
+                                   "DE":slice(11-1,20),
+                                   "DE_err":slice(21-1,30),
+                                   "D0":slice(31-1,40),
+                                   "D0_err":slice(41-1,50),
+                                   "DlnE":slice(51-1,60),
+                                   "DlnE_err":slice(51-1,60)}
         
 
 
@@ -281,6 +306,16 @@ class ParFile:
             lines.append("BROADENING PARAMETERS MAY BE VARIED".ljust(80))
             card = self.data["broadening"]
             lines.append(self._write_broadening(card))
+            lines.append(" "*80)
+            lines.append("")
+
+        # misc
+        if self.data["misc"]:
+            lines.append('MISCELLANEOUS PARAMETERS FOLLOW'.ljust(80))
+            card = self.data["misc"]
+            lines.append(self._write_misc_delta(card))
+            lines.append(self._write_misc_tzero(card))
+            lines.append(self._write_misc_deltE(card))
             lines.append(" "*80)
             lines.append("")
 
@@ -575,6 +610,35 @@ class ParFile:
             new_text[slice_value] = list(str(broadening_dict[key]).ljust(word_length))
         return "".join(new_text)
     
+    def _write_misc_delta(self,misc_delta_dict: dict) -> str:
+        # write a formated misc_delta line from dict with the key-word misc_delta values
+        new_text = [" "]*80 # 80 characters long list of spaces to be filled
+        new_text[:5] = list("DELTA")
+        for key,slice_value in self._MISC_DELTA_FORMAT.items():
+            word_length = slice_value.stop - slice_value.start
+            # assign the fixed-format position with the corresponding key-word value
+            new_text[slice_value] = list(str(misc_delta_dict[key]).ljust(word_length))
+        return "".join(new_text)
+
+    def _write_misc_tzero(self,misc_tzero_dict: dict) -> str:
+        # write a formated misc_tzero line from dict with the key-word misc_tzero values
+        new_text = [" "]*80 # 80 characters long list of spaces to be filled
+        new_text[:5] = list("TZERO")
+        for key,slice_value in self._MISC_TZERO_FORMAT.items():
+            word_length = slice_value.stop - slice_value.start
+            # assign the fixed-format position with the corresponding key-word value
+            new_text[slice_value] = list(str(misc_tzero_dict[key]).ljust(word_length))
+        return "".join(new_text)
+    
+    def _write_misc_deltE(self,misc_deltE_dict: dict) -> str:
+        # write a formated misc_deltE line from dict with the key-word misc_deltE values
+        new_text = [" "]*80 # 80 characters long list of spaces to be filled
+        new_text[:5] = list("DELTE")
+        for key,slice_value in self._MISC_DELTE_FORMAT.items():
+            word_length = slice_value.stop - slice_value.start
+            # assign the fixed-format position with the corresponding key-word value
+            new_text[slice_value] = list(str(misc_deltE_dict[key]).ljust(word_length))
+        return "".join(new_text)
 
 
 
@@ -837,6 +901,62 @@ class Update():
                                                  "vary_deltae_us":0,})     
 
         self.parent.data["broadening"].update(kwargs)
+
+    def misc(self, **kwargs) -> None:
+        """change or vary misc parameters and vary flags
+
+        Args:
+              - delta_L1 (float) DELL11
+              - delta_L1_err (float) D1
+              - delta_L0 (float) DELL00
+              - delta_L0_err (float) D0
+              - t0 (float) TZERO
+              - L0 (float) LZERO
+              - t0_err (float) DTZERO
+              - L0_err (float) DLZERO
+              - flight_path_length (float) FPL
+              - D0 (float) DELE0
+              - DE (float) DELE1
+              - DlnE (float) DELEL
+              - D0_err (float) DD0
+              - DE_err (float) DD1
+              - DlnE_err (float) DDL
+
+
+              - vary_delta_L1 (int) 0=fixed, 1=vary, 2=pup
+              - vary_delta_L0 (int) 0=fixed, 1=vary, 2=pup
+              - vary_L0 (int) 0=fixed, 1=vary, 2=pup
+              - vary_t0 (int) 0=fixed, 1=vary, 2=pup
+              - vary_D0 (int) 0=fixed, 1=vary, 2=pup
+              - vary_DE (int) 0=fixed, 1=vary, 2=pup
+              - vary_DlnE (int) 0=fixed, 1=vary, 2=pup
+        """
+        if "misc" not in self.parent.data:
+            self.parent.data["misc"] = {"vary_delta_L1":       "0",                     
+                                        "vary_delta_L0":       "0",                     
+                                        "delta_L1":            "",             
+                                        "delta_L1_err":        "",                 
+                                        "delta_L0":            "",             
+                                        "delta_L0_err":        "",                 
+                                        "vary_t0":             "0",             
+                                        "vary_L0":             "0",             
+                                        "t0":                  "",         
+                                        "t0_err":              "",             
+                                        "L0":                  "",         
+                                        "L0_err":              "",             
+                                        "flight_path_length":  "",                         
+                                        "vary_DE":             "0",             
+                                        "vary_D0":             "0",             
+                                        "vary_DlnE":           "0",                 
+                                        "DE":                  "",         
+                                        "DE_err":              "",             
+                                        "D0":                  "",         
+                                        "D0_err":              "",             
+                                        "DlnE":                "",         
+                                        "DlnE_err":            "",             
+                                         }
+
+        self.parent.data["misc"].update(kwargs)
 
      
 

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -111,6 +111,7 @@ class ParFile:
                                      "vary_flight_path_spread":slice(67-1,68),
                                      "vary_deltag_fwhm":slice(69-1,70),
                                      "vary_deltae_us":slice(71-1,72)}
+        
 
 
     def read(self) -> 'ParFile':
@@ -740,10 +741,11 @@ class Update():
                 card["vary_fission2_width"] = f"{1:>2}" if vary else f"{0:>2}"
 
 
-    def normalization(self,**kwargs) -> None:
+    def normalization(self, vary:bool = False, **kwargs) -> None:
         """change or vary normalization parameters and vary flags
 
         Args:
+              - vary (bool): if True all parameters are set to "vary", otherwise all set to "fixed"
               - normalization (float)
               - constant_bg (float)
               - one_over_v_bg (float)
@@ -770,12 +772,29 @@ class Update():
                                                  "vary_sqrt_energy_bg":0,
                                                  "vary_exponential_bg":0,
                                                  "vary_exp_decay_bg":0,}
-        self.parent.data["normalization"].update(**kwargs)
+        if vary:
+            self.parent.data["normalization"].update({"vary_normalization":1,
+                                                 "vary_constant_bg":1,
+                                                 "vary_one_over_v_bg":1,
+                                                 "vary_sqrt_energy_bg":1,
+                                                 "vary_exponential_bg":1,
+                                                 "vary_exp_decay_bg":1,}) 
+        else:
+            self.parent.data["normalization"].update({"vary_normalization":0,
+                                                 "vary_constant_bg":0,
+                                                 "vary_one_over_v_bg":0,
+                                                 "vary_sqrt_energy_bg":0,
+                                                 "vary_exponential_bg":0,
+                                                 "vary_exp_decay_bg":0,})     
+                       
+        self.parent.data["normalization"].update(kwargs)
 
-    def broadening(self,**kwargs) -> None:
+
+    def broadening(self, vary: bool=False, **kwargs) -> None:
         """change or vary broadening parameters and vary flags
 
         Args:
+              - vary (bool): if True all parameters are set to "vary", otherwise all set to "fixed"
               - channel_radius (float) CRFN
               - temperature (float) TEMP
               - thickness (float) THICK
@@ -802,7 +821,22 @@ class Update():
                                                  "vary_flight_path_spread":0,
                                                  "vary_deltag_fwhm":0,
                                                  "vary_deltae_us":0,}
-        self.parent.data["broadening"].update(**kwargs)
+        if vary:
+            self.parent.data["broadening"].update({"vary_channel_radius":1,
+                                                 "vary_temperature":1,
+                                                 "vary_thickness":1,
+                                                 "vary_flight_path_spread":1,
+                                                 "vary_deltag_fwhm":1,
+                                                 "vary_deltae_us":1,}) 
+        else:
+            self.parent.data["broadening"].update({"vary_channel_radius":0,
+                                                 "vary_temperature":0,
+                                                 "vary_thickness":0,
+                                                 "vary_flight_path_spread":0,
+                                                 "vary_deltag_fwhm":0,
+                                                 "vary_deltae_us":0,})     
+
+        self.parent.data["broadening"].update(kwargs)
 
      
 

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -144,7 +144,71 @@ class ParFile:
                                 #    "DlnE_err":slice(61-1,70)
                                   }
         
-
+        self._RESOLUTION_FORMAT = {"burst_keyword":slice(1-1,5),
+                                   "vary_burst":slice(7-1,7),
+                                   "burst":slice(11-1,20),
+                                   "tau_keyword":slice(1-1+81,5+81),
+                                   "vary_tau1":slice(6-1+81,6+81),
+                                   "vary_tau2":slice(7-1+81,7+81),
+                                   "vary_tau3":slice(8-1+81,8+81),
+                                   "vary_tau4":slice(9-1+81,9+81),
+                                   "vary_tau5":slice(10-1+81,10+81),
+                                   "tau1":slice(11-1+81,20+81),
+                                   "tau2":slice(21-1+81,30+81),
+                                   "tau3":slice(31-1+81,40+81),
+                                   "tau4":slice(41-1+81,50+81),
+                                   "tau5":slice(51-1+81,60+81),
+                                   "tau6":slice(61-1+81,70+81),
+                                   "tau7":slice(71-1+81,80+81),
+                                   "tau_keyword2":slice(1-1+162,5+162),
+                                   "vary_tau6":slice(6-1+162,6+162),
+                                   "vary_tau7":slice(7-1+162,7+162),
+                                   "lambd_keyword":slice(1-1+243,5+243),
+                                   "vary_lambd0":slice(6-1+243,6+243),
+                                   "vary_lambd1":slice(7-1+243,7+243),
+                                   "vary_lambd2":slice(8-1+243,8+243),
+                                   "vary_lambd3":slice(9-1+243,9+243),
+                                   "vary_lambd4":slice(10-1+243,10+243),
+                                   "lambd0":slice(11-1+243,20+243),
+                                   "lambd1":slice(21-1+243,30+243),
+                                   "lambd2":slice(31-1+243,40+243),
+                                   "lambd3":slice(41-1+243,50+243),  
+                                   "lambd4":slice(51-1+243,60+243), 
+                                   "lambd_keyword2":slice(1-1+324,5+324),
+                                   "a1_keyword":slice(1-1+405,5+405),
+                                   "vary_a1":slice(6-1+405,6+405),
+                                   "vary_a2":slice(7-1+405,7+405),
+                                   "vary_a3":slice(8-1+405,8+405),
+                                   "vary_a4":slice(9-1+405,9+405),
+                                   "vary_a5":slice(10-1+405,10+405),
+                                   "a1":slice(11-1+405,20+405),
+                                   "a2":slice(21-1+405,30+405),
+                                   "a3":slice(31-1+405,40+405),
+                                   "a4":slice(41-1+405,50+405),
+                                   "a5":slice(51-1+405,60+405),
+                                   "a6":slice(61-1+405,70+405),
+                                   "a7":slice(71-1+405,80+405), 
+                                   "a1_keyword2":slice(1-1+486,5+486),
+                                   "vary_a6":slice(6-1+486,6+486),
+                                   "vary_a7":slice(7-1+486,7+486),  
+                                   "expon_keyword":slice(1-1+567,5+567),
+                                   "vary_expon_t0":slice(6-1+567,6+567),
+                                   "vary_expon_a2":slice(7-1+567,7+567),
+                                   "vary_expon_a3":slice(8-1+567,8+567),
+                                   "vary_expon_a4":slice(9-1+567,9+567),
+                                   "vary_expon_a5":slice(10-1+567,10+567),
+                                   "expon_t0":slice(11-1+567,20+567),
+                                   "expon_a2":slice(21-1+567,30+567),
+                                   "expon_a3":slice(31-1+567,40+567),
+                                   "expon_a4":slice(41-1+567,50+567),  
+                                   "expon_a5":slice(51-1+567,60+567),  
+                                   "expon_keyword2":slice(1-1+648,5+648),   
+                                   "chann_keyword":slice(1-1+729,5+729),  
+                                   "vary_chann":slice(7-1+729,7+729),
+                                   "chann_emax":slice(11-1+729,20+729),
+                                   "chann":slice(21-1+729,30+729)
+                                  }
+        
 
     def read(self) -> 'ParFile':
         """Reads SAMMY .par file into data-structure that allows updating values
@@ -238,6 +302,7 @@ class ParFile:
             self.update.vary_all_resonances(False)
             self.update.normalization()
             self.update.broadening()
+            self.update.resolution()
             
 
         return self
@@ -327,6 +392,14 @@ class ParFile:
                 lines.append(self._write_misc_tzero(card))
             if any([value for key,value in self.data["misc"].items() if key in self._MISC_DELTE_FORMAT]):
                 lines.append(self._write_misc_deltE(card))
+            lines.append(" "*80)
+            lines.append("")
+
+        # resolution
+        if any(self.data["resolution"].values()):
+            lines.append("RPI RESOLUTION PARAMETERS FOLLOW".ljust(80))
+            card = self.data["resolution"]
+            lines.append(self._write_resolution(card))
             lines.append(" "*80)
             lines.append("")
 
@@ -660,6 +733,20 @@ class ParFile:
             new_text[slice_value] = list(str(misc_deltE_dict[key]).ljust(word_length))
         return "".join(new_text)
 
+    def _write_resolution(self,resolution_dict: dict) -> str:
+        # write a formated resolution line from dict with the key-word resolution values
+        new_text =([" "]*80 +["\n"])*9# 80 characters long list of spaces to be filled
+        resolution_dict["burst_keyword"] = "BURST"
+        resolution_dict["tau_keyword"] = resolution_dict["tau_keyword2"] = "TAU  "
+        resolution_dict["lambd_keyword"] = resolution_dict["lambd_keyword2"] = "LAMBD"
+        resolution_dict["a1_keyword"] = resolution_dict["a1_keyword2"] = "A1   "
+        resolution_dict["expon_keyword"] = resolution_dict["expon_keyword2"] = "EXPON"
+        resolution_dict["chann_keyword"] = "CHANN"
+        for key,slice_value in self._RESOLUTION_FORMAT.items():
+            word_length = slice_value.stop - slice_value.start
+            # assign the fixed-format position with the corresponding key-word value
+            new_text[slice_value] = list(str(resolution_dict[key]).ljust(word_length))
+        return "".join(new_text)
 
 
 
@@ -965,6 +1052,139 @@ class Update():
 
         self.parent.data["misc"].update({key:value for key,value in kwargs.items() if key in self.parent.data["misc"]})
 
+
+    def resolution(self, **kwargs) -> None:
+        """change or vary resolution parameters and vary flags
+
+        Args:
+            - vary_burst  (int) 0=fixed, 1=vary, 2=pup
+            - burst (float)
+
+            - vary_tau1  (int) 0=fixed, 1=vary, 2=pup
+            - vary_tau2  (int) 0=fixed, 1=vary, 2=pup
+            - vary_tau3  (int) 0=fixed, 1=vary, 2=pup
+            - vary_tau4  (int) 0=fixed, 1=vary, 2=pup
+            - vary_tau5  (int) 0=fixed, 1=vary, 2=pup
+            - tau1 (float)
+            - tau2 (float)
+            - tau3 (float)
+            - tau4 (float)
+            - tau5 (float)
+            - tau6 (float)
+            - tau7 (float)
+            - vary_tau6  (int) 0=fixed, 1=vary, 2=pup
+            - vary_tau7  (int) 0=fixed, 1=vary, 2=pup
+
+            - vary_lambd0  (int) 0=fixed, 1=vary, 2=pup
+            - vary_lambd1  (int) 0=fixed, 1=vary, 2=pup
+            - vary_lambd2  (int) 0=fixed, 1=vary, 2=pup
+            - vary_lambd3  (int) 0=fixed, 1=vary, 2=pup
+            - vary_lambd4  (int) 0=fixed, 1=vary, 2=pup
+            - lambd0 (float)
+            - lambd1 (float)
+            - lambd2 (float)
+            - lambd3 (float)
+            - lambd4 (float)
+
+
+            - vary_a1  (int) 0=fixed, 1=vary, 2=pup
+            - vary_a2  (int) 0=fixed, 1=vary, 2=pup
+            - vary_a3  (int) 0=fixed, 1=vary, 2=pup
+            - vary_a4  (int) 0=fixed, 1=vary, 2=pup
+            - vary_a5  (int) 0=fixed, 1=vary, 2=pup
+            - a1 (float)
+            - a2 (float)
+            - a3 (float)
+            - a4 (float)
+            - a5 (float)
+            - a6 (float)
+            - a7 (float)
+            - vary_a6  (int) 0=fixed, 1=vary, 2=pup
+            - vary_a7  (int) 0=fixed, 1=vary, 2=pup
+
+            - vary_expon_t0  (int) 0=fixed, 1=vary, 2=pup
+            - vary_expon_a2  (int) 0=fixed, 1=vary, 2=pup
+            - vary_expon_a3  (int) 0=fixed, 1=vary, 2=pup
+            - vary_expon_a4  (int) 0=fixed, 1=vary, 2=pup
+            - vary_expon_a5  (int) 0=fixed, 1=vary, 2=pup
+            - expon_t0 (float)
+            - expon_a2 (float)
+            - expon_a3 (float)
+            - expon_a4 (float)
+            - expon_a5 (float)
+
+            - vary_chann (float)
+            - chann_emax (float)
+            - chann (float)
+        """
+        if "resolution" not in self.parent.data:
+            self.parent.data["resolution"] = {"burst_keyword": "",
+                                        "vary_burst": "",
+                                        "burst": "",
+                                        "tau_keyword": "",
+                                        "vary_tau1": "",
+                                        "vary_tau2": "",
+                                        "vary_tau3": "",
+                                        "vary_tau4": "",
+                                        "vary_tau5": "",
+                                        "tau1": "",
+                                        "tau2": "",
+                                        "tau3": "",
+                                        "tau4": "",
+                                        "tau5": "",
+                                        "tau6": "",
+                                        "tau7": "",
+                                        "tau_keyword2": "",
+                                        "vary_tau6": "",
+                                        "vary_tau7": "",
+                                        "lambd_keyword": "",
+                                        "vary_lambd0": "",
+                                        "vary_lambd1": "",
+                                        "vary_lambd2": "",
+                                        "vary_lambd3": "",
+                                        "vary_lambd4": "",
+                                        "lambd0": "",
+                                        "lambd1": "",
+                                        "lambd2": "",
+                                        "lambd3": "",
+                                        "lambd4": "",
+                                        "lambd_keyword2": "",
+                                        "a1_keyword": "",
+                                        "vary_a1": "",
+                                        "vary_a2": "",
+                                        "vary_a3": "",
+                                        "vary_a4": "",
+                                        "vary_a5": "",
+                                        "a1": "",
+                                        "a2": "",
+                                        "a3": "",
+                                        "a4": "",
+                                        "a5": "",
+                                        "a6": "",
+                                        "a7": "",
+                                        "a1_keyword2": "",
+                                        "vary_a6": "",
+                                        "vary_a7": "",
+                                        "expon_keyword": "",
+                                        "vary_expon_t0": "",
+                                        "vary_expon_a2": "",
+                                        "vary_expon_a3": "",
+                                        "vary_expon_a4": "",
+                                        "vary_expon_a5": "",
+                                        "expon_t0": "",
+                                        "expon_a2": "",
+                                        "expon_a3": "",
+                                        "expon_a4": "",
+                                        "expon_a5": "",
+                                        "expon_keyword2": "",
+                                        "chann_keyword": "",
+                                        "vary_chann": "",
+                                        "chann_emax": "",
+                                        "chann": ""}
+
+        self.parent.data["resolution"].update({key:value for key,value in kwargs.items() if key in self.parent.data["resolution"]})
+
+
                                                  
     def vary_all(self,vary=True,data_key="misc_delta"):
         """toggle all vary parameters in a data keyword to either vary/fixed
@@ -988,7 +1208,7 @@ class Update():
         with open(inifilename,"w") as fid:
             config = configparser.ConfigParser()
             config.optionxform = str
-            config.update({key:self.parent.data[key] for key in ['info','normalization', 'broadening', 'misc']})
+            config.update({key:self.parent.data[key] for key in ['info','normalization', 'broadening', 'misc','resolution']})
             config.write(fid)
 
 

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -33,7 +33,9 @@ class ParFile:
         self.emax = emax
 
         self.data = {}
-        self.data["fudge_factor"] = 0.1
+        self.data["info"] = {}
+        self.data["info"]["fudge_factor"] = 0.1
+        self.data["info"]["filename"] = filename
 
         # group all update methods in the Update class (and the `update`` namespace)
         self.update = Update(self)
@@ -275,7 +277,7 @@ class ParFile:
         for card in self.data["resonance_params"]:
             lines.append(self._write_resonance_params(card))
         lines.append(" "*80)
-        lines.append(f"{self.data['fudge_factor']:<11}")
+        lines.append(f"{self.data["info"]['fudge_factor']:<11}")
         lines.append(" "*80)
 
         # channel radii
@@ -331,7 +333,7 @@ class ParFile:
         # write the self.data dictionary to a config.ini file
         with open(f'{filename.with_name("params.ini")}',"w") as fid:
             config = configparser.ConfigParser()
-            config.update({key:self.data[key] for key in ['normalization', 'broadening', 'misc']})
+            config.update({key:self.data[key] for key in ['info','normalization', 'broadening', 'misc']})
             config.write(fid)
 
         
@@ -364,7 +366,7 @@ class ParFile:
                         channel["channel_name"] = new_name
 
             reaction["name"] = new_name
-
+        self.data["info"][name] = self.weight
         self.name = name
 
 
@@ -405,6 +407,7 @@ class ParFile:
             # update isotopic_masses
             compound.data["isotopic_masses"] += isotope.data["isotopic_masses"]
 
+            compound.data["info"].update(isotope.data["info"])
         return compound
 
 
@@ -742,6 +745,7 @@ class Update():
         """
         for isotope in self.parent.data["isotopic_masses"]:
             isotope["vary_abundance"] = f"{vary:<5}"
+            self.parent.data["info"][f"vary_{self.name}"] = f"{vary:<5}"
 
 
     def limit_energies_of_parfile(self) -> None:

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -810,7 +810,7 @@ class Update():
         """
         if "broadening" not in self.parent.data:
             self.parent.data["broadening"] = {"channel_radius":"",
-                                                 "temperature":"",
+                                                 "temperature":"296.",
                                                  "thickness":"",
                                                  "flight_path_spread":"",
                                                  "deltag_fwhm":"",

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -31,6 +31,7 @@ class ParFile:
         self.name = name
         self.emin = emin
         self.emax = emax
+        self.energy_range_pad = 0.3 # 30% above emax and below emin
 
         self.data = {}
         self.data["info"] = {}
@@ -755,7 +756,15 @@ class Update():
         for num, res in enumerate(self.parent.data["resonance_params"]):
             # cast all numbers such as "3.6700-5" to floats
             energy = "e-".join(res['reosnance_energy'].split("-")).lstrip("e").replace("+","e+") if not "e" in res['reosnance_energy'] else res['reosnance_energy']
-            if float(self.parent.emin) <=  float(energy) < float(self.parent.emax):
+            if self.parent.emin<5.:
+                # if emin is low anyway, grab all resonances down to below zro
+                emin = -100.
+            else:
+                emin = float(self.parent.emin)*(1.-self.parent.energy_range_pad)
+            emax = float(self.parent.emax)*(1.+self.parent.energy_range_pad)
+            self.parent.data["info"]["emin"] = emin
+            self.parent.data["info"]["emax"] = emax
+            if emin <=  float(energy) < emax:
                 new_res_params.append(res)
                 igroups.add(res["igroup"].strip())
         

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -805,7 +805,7 @@ class Update():
         """Update the isotopic weight in the spin_group data
         """
         for group in self.parent.data["spin_group"]:
-            group[0]["isotopic_abundance"] = f"{f'{self.parent.weight:.7f}':>10}"
+            group[0]["isotopic_abundance"] = f"{f'{self.parent.weight:.7f}':>9}"[:9]
 
 
     def isotopic_masses_abundance(self) -> None:
@@ -813,7 +813,7 @@ class Update():
         """
         if self.parent.data["isotopic_masses"]:
             for card in self.parent.data["isotopic_masses"]:
-                card["abundance"] = f"{f'{self.parent.weight:.7f}':>9}"
+                card["abundance"] = f"{f'{self.parent.weight:.7f}':>9}"[:9]
         else:
             spin_groups = [f"{group[0]['group_number'].strip():>5}" for group in self.parent.data["spin_group"]]
                 
@@ -822,9 +822,9 @@ class Update():
             for l in range(0,L+1):
                 sg_formatted += "-1\n" + "".join(spin_groups[8+15*l:8+15*(l+1)]).ljust(78)
                 
-            iso_dict = {"atomic_mass":f'{float(self.parent.data["particle_pairs"][0]["mass_b"]):>9}',
-                        "abundance":f"{f'{self.parent.weight:.7f}':>9}",
-                        "abundance_uncertainty":f"{f'{self.parent.weight*0.1:.7f}':>9}",
+            iso_dict = {"atomic_mass":f'{float(self.parent.data["particle_pairs"][0]["mass_b"]):>9}'[:9],
+                        "abundance":f"{f'{self.parent.weight:.7f}':>9}"[:9],
+                        "abundance_uncertainty":f"{f'':>9}",
                         "vary_abundance":"1".ljust(5),
                         "spin_groups":sg_formatted}
             self.parent.data["isotopic_masses"][self.parent.name] = iso_dict

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -735,7 +735,7 @@ class ParFile:
 
     def _write_resolution(self,resolution_dict: dict) -> str:
         # write a formated resolution line from dict with the key-word resolution values
-        new_text =([" "]*80 +["\n"])*9# 80 characters long list of spaces to be filled
+        new_text =([" "]*80 +["\n"])*10# 80 characters long list of spaces to be filled
         resolution_dict["burst_keyword"] = "BURST"
         resolution_dict["tau_keyword"] = resolution_dict["tau_keyword2"] = "TAU  "
         resolution_dict["lambd_keyword"] = resolution_dict["lambd_keyword2"] = "LAMBD"

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -805,11 +805,10 @@ class Update():
                 card["vary_fission2_width"] = f"{1:>2}" if vary else f"{0:>2}"
 
 
-    def normalization(self, vary:bool = False, **kwargs) -> None:
+    def normalization(self, **kwargs) -> None:
         """change or vary normalization parameters and vary flags
 
         Args:
-              - vary (bool): if True all parameters are set to "vary", otherwise all set to "fixed"
               - normalization (float)
               - constant_bg (float)
               - one_over_v_bg (float)
@@ -835,30 +834,15 @@ class Update():
                                                  "vary_one_over_v_bg":0,
                                                  "vary_sqrt_energy_bg":0,
                                                  "vary_exponential_bg":0,
-                                                 "vary_exp_decay_bg":0,}
-        if vary:
-            self.parent.data["normalization"].update({"vary_normalization":1,
-                                                 "vary_constant_bg":1,
-                                                 "vary_one_over_v_bg":1,
-                                                 "vary_sqrt_energy_bg":1,
-                                                 "vary_exponential_bg":1,
-                                                 "vary_exp_decay_bg":1,}) 
-        else:
-            self.parent.data["normalization"].update({"vary_normalization":0,
-                                                 "vary_constant_bg":0,
-                                                 "vary_one_over_v_bg":0,
-                                                 "vary_sqrt_energy_bg":0,
-                                                 "vary_exponential_bg":0,
-                                                 "vary_exp_decay_bg":0,})     
+                                                 "vary_exp_decay_bg":0,}    
                        
         self.parent.data["normalization"].update(kwargs)
 
 
-    def broadening(self, vary: bool=False, **kwargs) -> None:
+    def broadening(self, **kwargs) -> None:
         """change or vary broadening parameters and vary flags
 
         Args:
-              - vary (bool): if True all parameters are set to "vary", otherwise all set to "fixed"
               - channel_radius (float) CRFN
               - temperature (float) TEMP
               - thickness (float) THICK
@@ -885,20 +869,6 @@ class Update():
                                                  "vary_flight_path_spread":0,
                                                  "vary_deltag_fwhm":0,
                                                  "vary_deltae_us":0,}
-        if vary:
-            self.parent.data["broadening"].update({"vary_channel_radius":1,
-                                                 "vary_temperature":1,
-                                                 "vary_thickness":1,
-                                                 "vary_flight_path_spread":1,
-                                                 "vary_deltag_fwhm":1,
-                                                 "vary_deltae_us":1,}) 
-        else:
-            self.parent.data["broadening"].update({"vary_channel_radius":0,
-                                                 "vary_temperature":0,
-                                                 "vary_thickness":0,
-                                                 "vary_flight_path_spread":0,
-                                                 "vary_deltag_fwhm":0,
-                                                 "vary_deltae_us":0,})     
 
         self.parent.data["broadening"].update(kwargs)
 
@@ -957,6 +927,24 @@ class Update():
                                          }
 
         self.parent.data["misc"].update(kwargs)
+
+                                                 
+    def set_all_vary(self,vary=True,data_key="misc_delta"):
+        """toggle all vary parameters in a data keyword to either vary/fixed
+
+        Args:
+            vary (bool, optional): If True the parameters are set to vary, else all are set to fixed
+            data_key (str, optional): choice of one of the followings:
+                        - 'misc_delta'
+                        - 'misc_tzero'
+                        - 'misc_deltE'
+                        - 'broadeninig'
+                        - 'normalization'
+        """
+        key_word = data_key.split("_")[0]
+        data_dict = getattr(self,f"_{data_key.upper()}_FORMAT")
+        self.parent.data[keyword].update({key:int(vary) for key in data_dict if key.startswith("vary_")})
+
 
      
 

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -99,13 +99,11 @@ class ParFile:
                                      "vary_exponential_bg":slice(69-1,70),
                                      "vary_exp_decay_bg":slice(71-1,72)}
         
-        self._BROADENING_FORMAT = {"channel_radius":slice(1-1,10),
-                                     "temperature":slice(11-1,20),
+        self._BROADENING_FORMAT = {  "temperature":slice(11-1,20),
                                      "thickness":slice(21-1,30),
                                      "flight_path_spread":slice(31-1,40),
                                      "deltag_fwhm":slice(41-1,50),
                                      "deltae_us":slice(51-1,60),
-                                     "vary_channel_radius":slice(61-1,62),
                                      "vary_temperature":slice(63-1,64),
                                      "vary_thickness":slice(65-1,66),
                                      "vary_flight_path_spread":slice(67-1,68),
@@ -857,13 +855,11 @@ class Update():
               - vary_deltae_us (int) 0=fixed, 1=vary, 2=pup
         """
         if "broadening" not in self.parent.data:
-            self.parent.data["broadening"] = {"channel_radius":"",
-                                                 "temperature":"296.",
+            self.parent.data["broadening"] = {  "temperature":"296.",
                                                  "thickness":"",
                                                  "flight_path_spread":"",
                                                  "deltag_fwhm":"",
                                                  "deltae_us":"",
-                                                 "vary_channel_radius":0,
                                                  "vary_temperature":0,
                                                  "vary_thickness":0,
                                                  "vary_flight_path_spread":0,

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -397,7 +397,7 @@ class ParFile:
 
         # resolution
         if any(self.data["resolution"].values()):
-            lines.append("RPI RESOLUTION PARAMETERS FOLLOW".ljust(80))
+            lines.append("RESOLUTION PARAMETERS FOLLOW".ljust(80))
             card = self.data["resolution"]
             lines.append(self._write_resolution(card))
             lines.append(" "*80)

--- a/pleiades/sammyParFile.py
+++ b/pleiades/sammyParFile.py
@@ -844,13 +844,11 @@ class Update():
         """change or vary broadening parameters and vary flags
 
         Args:
-              - channel_radius (float) CRFN
               - temperature (float) TEMP
               - thickness (float) THICK
               - flight_path_spread (float) DELTAL
               - deltag_fwhm (float) DELTAG
               - deltae_us (float) DELTAE
-              - vary_channel_radius (int) 0=fixed, 1=vary, 2=pup
               - vary_temperature (int) 0=fixed, 1=vary, 2=pup
               - vary_thickness (int) 0=fixed, 1=vary, 2=pup
               - vary_flight_path_spread (int) 0=fixed, 1=vary, 2=pup

--- a/pleiades/sammyRunner.py
+++ b/pleiades/sammyRunner.py
@@ -44,7 +44,8 @@ def run(archivename: str="example",
         shutil.copy(datafile, archivepath / f'{archivename}.dat')
         datafile = f'{archivename}.dat'
     except FileNotFoundError:
-        print(f"grab files from within the {archivepath} directory")
+        # print(f"grab files from within the {archivepath} directory")
+        pass
 
     outputfile = f'{archivename}.out'
 

--- a/pleiades/sammyRunner.py
+++ b/pleiades/sammyRunner.py
@@ -36,12 +36,15 @@ def run(archivename: str="example",
 
 
     # copy files into archive
-    shutil.copy(inpfile, archivepath / f'{archivename}.inp')
-    inpfile = f'{archivename}.inp'
-    shutil.copy(parfile, archivepath / f'{archivename}.par')
-    parfile = f'{archivename}.par'
-    shutil.copy(datafile, archivepath / f'{archivename}.dat')
-    datafile = f'{archivename}.dat'
+    try:
+        shutil.copy(inpfile, archivepath / f'{archivename}.inp')
+        inpfile = f'{archivename}.inp'
+        shutil.copy(parfile, archivepath / f'{archivename}.par')
+        parfile = f'{archivename}.par'
+        shutil.copy(datafile, archivepath / f'{archivename}.dat')
+        datafile = f'{archivename}.dat'
+    except FileNotFoundError:
+        print(f"grab files from within the {archivepath} directory")
 
     outputfile = f'{archivename}.out'
 
@@ -87,9 +90,15 @@ def run_endf(inpfile: str = "") -> None:
     import os
     import shutil
 
-    archivename = inpfile.split(".")[0]
+    inpfile= pathlib.Path(inpfile)
+    archivename = pathlib.Path(inpfile.stem)
 
-    archivepath = pathlib.Path(f"archive/{archivename}") 
+    # read the input file to get the Emin and Emax:
+    with open(inpfile) as fid:
+        next(fid)
+        Emin, Emax = next(fid).split()[2:4]
+
+    archivepath = pathlib.Path("archive") / archivename
 
     # create an archive directory
     os.makedirs(archivepath,exist_ok=True)
@@ -97,13 +106,11 @@ def run_endf(inpfile: str = "") -> None:
 
 
     # copy files into archive
-    shutil.copy(inpfile, archivepath / f'{archivename}.inp')
-    inpfile = f'{archivename}.inp'
+    shutil.copy(inpfile, archivepath / archivename.with_suffix(".inp"))
+    inpfile = archivename.with_suffix(".inp")
+    
 
-    # read the input file to get the Emin and Emax:
-    with open(inpfile) as fid:
-        next(fid)
-        Emin, Emax = next(fid).split()[2:4]
+
 
     # write a fake datafile with two entries of Emin and Emax
     with open(archivepath / f'{archivename}.dat',"w") as fid:


### PR DESCRIPTION
Add `MISC` cards in the par file
- [x] `TZERO` - option to calibrate the flight-path-length and time delay in sammy $L = L_0\cdot x + v(t-t_0) $
- [x] `DELTA` - vary parameters for the moderator ($\Delta_L$) resolution
- [x] `DELTE` - time resolution broadening $\Delta t = D_0 + D_1 E + D_2 ln(E) $

Add parsing options in sammyOutput

- [x] `register_abundances_stats`
- [x] `register_normalization_stats`
- [x] `register_broadening_stats`
- [x] `register_misc_stats`